### PR TITLE
Use a dictionary for exec locals in setup.py version function

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,14 @@
 import os
 from setuptools import setup, find_packages
 
-try: # for pip >= 10
+try:  # for pip >= 10
     from pip._internal.req import parse_requirements
-except ImportError: # for pip <= 9.0.3
+except ImportError:  # for pip <= 9.0.3
     from pip.req import parse_requirements
 
-try: # for pip >= 10
+try:  # for pip >= 10
     from pip._internal.download import PipSession
-except ImportError: # for pip <= 9.0.3
+except ImportError:  # for pip <= 9.0.3
     from pip.download import PipSession
 
 
@@ -25,8 +25,11 @@ def get_requirements():
 def get_version():
     __version__ = None
     with open('needinit/_version.py') as version_src:
-        exec(version_src.read())
+        namespace = {}
+        exec(version_src.read(), namespace)
+        __version__ = namespace.get('__version__')
     return __version__
+
 
 setup(
     name='needinit',


### PR DESCRIPTION
`exec` behaviour is different between python 2 and 3. See [this SO thread for more info](https://stackoverflow.com/questions/15086040/behavior-of-exec-function-in-python-2-and-python-3)

I've updated the `get_version` function to use a locals dictionary when calling `exec` and fetch the version from it.

But is there really a reason to have the `_version.py` an actual python file? It doesn't seem to be used outside of here and could just be a text file where we read the version directly.

Version is being reported correctly with both python 2 and 3:

```
-> % python2 setup.py install | tail -1
Finished processing dependencies for needinit==0.2.0
-> % python3 setup.py install | tail -1
Finished processing dependencies for needinit==0.2.0
```

Resolves #2 